### PR TITLE
startup: add PACKAGE-LOCAL-NICKNAMES to *features*

### DIFF
--- a/runtime/Startup.cs
+++ b/runtime/Startup.cs
@@ -113,7 +113,7 @@ public static class Startup
     // Features list
     private static readonly HashSet<string> _features = new()
     {
-        "DOTCL", "COMMON-LISP", "NET", "UNICODE"
+        "DOTCL", "COMMON-LISP", "NET", "UNICODE", "PACKAGE-LOCAL-NICKNAMES"
     };
 
     private static bool _initialized;


### PR DESCRIPTION
## Summary

It adds `PACKAGE-LOCAL-NICKNAMES` to `*features*`, since this implementation seems to support them.

## Related issues

N/A

## Testing

- [X] `make cross-compile` succeeds
- [X] `make test-regression` passes
- [X] `make test-ansi-full` passes (if runtime/compiler is touched broadly)