### PR TITLE
Fix backwards history in REPL up/down arrow

### DIFF
--- a/contrib/dotcl-repl/dotcl-repl.lisp
+++ b/contrib/dotcl-repl/dotcl-repl.lisp
@@ -252,7 +252,7 @@
 
           ;; Up arrow — history previous
           ((console-key= ki "UpArrow")
-           (let ((history (reverse *history*))
+           (let ((history *history*)
                  (next-idx (1+ hist-idx)))
              (when (< next-idx (length history))
                (when (= hist-idx -1)
@@ -267,7 +267,7 @@
            (cond
              ((> hist-idx 0)
               (decf hist-idx)
-              (let ((history (reverse *history*)))
+              (let ((history *history*))
                 (setf buf (coerce (nth hist-idx history) 'list))
                 (setf point (length buf))
                 (redraw prompt-col buf point)))


### PR DESCRIPTION
The way currently implemented, hitting UP for the first time will show the first thing entered into the REPL. What we want is it to show the last thing (most recently entered thing), and progressively step backwards until the final UP press reveals the first entered thing.

Patched the UP and DOWN keys to work this way.

## Testing

- [x] `make cross-compile` succeeds
- [x] `make test-regression` passes
- [x] `make test-ansi-full` passes (if runtime/compiler is touched broadly)

