### PR TITLE
runtime: streaming external-process handle (dotcl:launch-process)

### DIFF
--- a/runtime/Process.cs
+++ b/runtime/Process.cs
@@ -1,0 +1,102 @@
+namespace DotCL;
+
+/// <summary>A TextReader over a child process's redirected stdout/stderr that never
+/// truncates. Reading a process pipe directly from a tight CL loop (e.g. READ-LINE)
+/// races with the child exiting: a transient end-of-stream is mistaken for true EOF
+/// and the final buffered output is lost. To avoid that, a background thread drains
+/// the underlying pipe to true EOF in chunks (the canonical .NET pattern, as in
+/// ReadToEnd) into an in-memory buffer; the Lisp-facing reader consumes from that
+/// buffer, blocking until data is available or the drain has completed.</summary>
+public sealed class ProcessStreamReader : System.IO.TextReader
+{
+    private readonly System.Text.StringBuilder _buf = new();
+    private int _pos;
+    private bool _eof;
+    private readonly object _lock = new();
+
+    public ProcessStreamReader(System.IO.TextReader inner, System.Diagnostics.Process proc)
+    {
+        var drain = new System.Threading.Thread(() =>
+        {
+            try
+            {
+                var chunk = new char[4096];
+                int n;
+                while ((n = inner.Read(chunk, 0, chunk.Length)) > 0)
+                {
+                    lock (_lock) { _buf.Append(chunk, 0, n); System.Threading.Monitor.PulseAll(_lock); }
+                }
+            }
+            catch { /* pipe closed/broken — treat as EOF */ }
+            finally
+            {
+                lock (_lock) { _eof = true; System.Threading.Monitor.PulseAll(_lock); }
+                try { inner.Dispose(); } catch { }
+            }
+        })
+        { IsBackground = true, Name = "dotcl-process-drain" };
+        drain.Start();
+    }
+
+    public override int Read()
+    {
+        lock (_lock)
+        {
+            while (_pos >= _buf.Length && !_eof) System.Threading.Monitor.Wait(_lock);
+            return _pos < _buf.Length ? _buf[_pos++] : -1;
+        }
+    }
+
+    // Non-blocking: may report -1 even when more data is still coming
+    // (CL READ-CHAR-NO-HANG / LISTEN depend on Peek not blocking).
+    public override int Peek()
+    {
+        lock (_lock) { return _pos < _buf.Length ? _buf[_pos] : -1; }
+    }
+
+    public override int Read(char[] buffer, int index, int count)
+    {
+        if (count <= 0) return 0;
+        lock (_lock)
+        {
+            while (_pos >= _buf.Length && !_eof) System.Threading.Monitor.Wait(_lock);
+            int avail = _buf.Length - _pos;
+            if (avail <= 0) return 0;
+            int n = System.Math.Min(avail, count);
+            _buf.CopyTo(_pos, buffer, index, n);
+            _pos += n;
+            return n;
+        }
+    }
+}
+
+/// <summary>A live external process launched via dotcl:launch-process.
+/// Wraps System.Diagnostics.Process and exposes its redirected stdio as Lisp
+/// streams, so UIOP's launch-program/process-info protocol (and thus the full
+/// run-program contract via slurp-input-stream) can be implemented on top of it
+/// instead of the collect-all dotcl:run-process.</summary>
+public sealed class LispProcess : LispObject
+{
+    public System.Diagnostics.Process Process { get; }
+    /// <summary>Writable stream to the child's stdin (LispOutputStream over StandardInput).</summary>
+    public LispObject InputStream { get; }
+    /// <summary>Readable stream from the child's stdout (LispInputStream over StandardOutput).</summary>
+    public LispObject OutputStream { get; }
+    /// <summary>Readable stream from the child's stderr (LispInputStream over StandardError).</summary>
+    public LispObject ErrorStream { get; }
+
+    public LispProcess(System.Diagnostics.Process process,
+                       LispObject input, LispObject output, LispObject error)
+    {
+        Process = process;
+        InputStream = input;
+        OutputStream = output;
+        ErrorStream = error;
+    }
+
+    public override string ToString()
+    {
+        try { return $"#<PROCESS pid={Process.Id}>"; }
+        catch { return "#<PROCESS>"; }
+    }
+}

--- a/runtime/Startup.cs
+++ b/runtime/Startup.cs
@@ -1567,6 +1567,77 @@ public static class Startup
         RegisterDotcl("RUN-PROCESS", runProcess);
         RegisterDotcl("%RUN-PROCESS", runProcess); // backward-compat alias
 
+        // launch-process — streaming process handle for UIOP launch-program/process-info.
+        // Unlike run-process (collect-all), this exposes the child's stdin/stdout/
+        // stderr as live Lisp streams so the full run-program contract (incl. :input and
+        // every output spec) can be built on UIOP's slurp-input-stream.
+        // (launch-process exe arg-list &optional directory) -> #<PROCESS>
+        RegisterDotcl("LAUNCH-PROCESS", new LispFunction(args => {
+            var exe = args[0] is LispString es ? es.Value : args[0].ToString();
+            var argStrings = new System.Collections.Generic.List<string>();
+            if (args.Length > 1) {
+                var cur = args[1];
+                while (cur is Cons c) {
+                    argStrings.Add(c.Car is LispString ls ? ls.Value : c.Car.ToString());
+                    cur = c.Cdr;
+                }
+            }
+            var psi = new System.Diagnostics.ProcessStartInfo(exe) {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (var a in argStrings) psi.ArgumentList.Add(a);
+            if (args.Length > 2 && args[2] is LispString dir && dir.Value.Length > 0)
+                psi.WorkingDirectory = dir.Value;
+            var proc = System.Diagnostics.Process.Start(psi)!;
+            // Wrap stdout/stderr so a tight CL read loop blocks until true EOF
+            // instead of truncating on a transient empty-pipe read.
+            return new LispProcess(proc,
+                new LispOutputStream(proc.StandardInput),
+                new LispInputStream(new ProcessStreamReader(proc.StandardOutput, proc)),
+                new LispInputStream(new ProcessStreamReader(proc.StandardError, proc)));
+        }));
+        RegisterDotcl("PROCESS-INPUT", new LispFunction(args =>
+            args[0] is LispProcess p ? p.InputStream
+            : throw new LispErrorException(new LispTypeError("PROCESS-INPUT: not a process", args[0]))));
+        RegisterDotcl("PROCESS-OUTPUT", new LispFunction(args =>
+            args[0] is LispProcess p ? p.OutputStream
+            : throw new LispErrorException(new LispTypeError("PROCESS-OUTPUT: not a process", args[0]))));
+        RegisterDotcl("PROCESS-ERROR", new LispFunction(args =>
+            args[0] is LispProcess p ? p.ErrorStream
+            : throw new LispErrorException(new LispTypeError("PROCESS-ERROR: not a process", args[0]))));
+        RegisterDotcl("PROCESS-PID", new LispFunction(args =>
+            args[0] is LispProcess p ? (LispObject)new Fixnum(p.Process.Id)
+            : throw new LispErrorException(new LispTypeError("PROCESS-PID: not a process", args[0]))));
+        // process-wait: block until exit, return exit code (fixnum).
+        RegisterDotcl("PROCESS-WAIT", new LispFunction(args => {
+            if (args[0] is not LispProcess p)
+                throw new LispErrorException(new LispTypeError("PROCESS-WAIT: not a process", args[0]));
+            p.Process.WaitForExit();
+            return new Fixnum(p.Process.ExitCode);
+        }));
+        // process-alive-p: T while running, NIL once exited.
+        RegisterDotcl("PROCESS-ALIVE-P", new LispFunction(args =>
+            args[0] is LispProcess p
+                ? (p.Process.HasExited ? (LispObject)Nil.Instance : T.Instance)
+                : throw new LispErrorException(new LispTypeError("PROCESS-ALIVE-P: not a process", args[0]))));
+        // process-exit-code: fixnum if exited, NIL if still running.
+        RegisterDotcl("PROCESS-EXIT-CODE", new LispFunction(args => {
+            if (args[0] is not LispProcess p)
+                throw new LispErrorException(new LispTypeError("PROCESS-EXIT-CODE: not a process", args[0]));
+            return p.Process.HasExited ? (LispObject)new Fixnum(p.Process.ExitCode) : Nil.Instance;
+        }));
+        // process-kill: terminate the process (and its tree); returns NIL.
+        RegisterDotcl("PROCESS-KILL", new LispFunction(args => {
+            if (args[0] is not LispProcess p)
+                throw new LispErrorException(new LispTypeError("PROCESS-KILL: not a process", args[0]));
+            try { if (!p.Process.HasExited) p.Process.Kill(entireProcessTree: true); } catch { }
+            return Nil.Instance;
+        }));
+
         // Threading primitives — public dotcl: API backed by Runtime.Thread.cs.
         // bordeaux-threads impl-dotcl.lisp delegates to these.
         RegisterDotcl("MAKE-THREAD",

--- a/test/regression/process.lisp
+++ b/test/regression/process.lisp
@@ -1,0 +1,58 @@
+;;; Regression tests for dotcl:launch-process — streaming process handle.
+;;; Uses `dotnet --version` as a portable child process (present on Windows local
+;;; and Linux CI). Exercises the launch-program/process-info building blocks:
+;;; live output stream, pid, blocking wait, exit code, liveness.
+
+;;; output stream readable + blocking wait returns exit code 0
+(deftest d284-launch-process-output-and-exit
+  (let* ((p (dotcl:launch-process "dotnet" '("--version")))
+         (line (read-line (dotcl:process-output p) nil ""))
+         (code (dotcl:process-wait p)))
+    (list (eql code 0) (> (length line) 0)))
+  (t t))
+
+;;; process-pid is a positive integer
+(deftest d284-launch-process-pid-positive-integer
+  (let ((p (dotcl:launch-process "dotnet" '("--version"))))
+    (prog1 (and (integerp (dotcl:process-pid p))
+                (> (dotcl:process-pid p) 0)
+                t)
+      (dotcl:process-wait p)))
+  t)
+
+;;; after wait, process is no longer alive and exit-code is available
+(deftest d284-process-alive-p-and-exit-code
+  (let ((p (dotcl:launch-process "dotnet" '("--version"))))
+    (dotcl:process-wait p)
+    (list (dotcl:process-alive-p p) (dotcl:process-exit-code p)))
+  (nil 0))
+
+;;; process-output / process-error / process-input are streams
+(deftest d284-process-streams-are-streams
+  (let ((p (dotcl:launch-process "dotnet" '("--version"))))
+    (prog1 (list (streamp (dotcl:process-output p))
+                 (streamp (dotcl:process-error p))
+                 (streamp (dotcl:process-input p)))
+      (dotcl:process-wait p)))
+  (t t t))
+
+;;; writing to process-input reaches the child, and reading the child's
+;;; output never truncates. `sort` reads all of stdin then emits it sorted and
+;;; exits immediately; a tight read-line loop concurrent with that fast exit used
+;;; to drop the final line (transient empty-pipe read mistaken for EOF) before
+;;; ProcessStreamReader drained the pipe to true EOF. Runs a few times because
+;;; the truncation was timing-sensitive.
+(deftest d284-process-input-and-no-output-truncation
+  (flet ((sort3 ()
+           (let* ((p (dotcl:launch-process "sort" '()))
+                  (in (dotcl:process-input p))
+                  (out (dotcl:process-output p)))
+             (write-line "banana" in)
+             (write-line "apple" in)
+             (write-line "cherry" in)
+             (close in)
+             (prog1 (loop for line = (read-line out nil nil) while line
+                          collect (string-right-trim '(#\return) line))
+               (dotcl:process-wait p)))))
+    (loop repeat 5 always (equal (sort3) '("apple" "banana" "cherry"))))
+  t)

--- a/test/regression/run.lisp
+++ b/test/regression/run.lisp
@@ -18,6 +18,7 @@
 (load "test/regression/call-out.lisp")
 (load "test/regression/static-generic.lisp")
 (load "test/regression/native-int-arith.lisp")
+(load "test/regression/process.lisp")
 
 (do-tests-summary)
 (if (= *fail-count* 0)


### PR DESCRIPTION
## Summary

Add a streaming external-process primitive, `dotcl:launch-process`, alongside the
existing collect-all `dotcl:run-process`. It exposes a child process's
stdin/stdout/stderr as live Lisp streams plus pid / wait / alive-p / exit-code /
kill — the building blocks UIOP's `launch-program` / `process-info` protocol (and
thus the full `run-program` contract via `slurp-input-stream`) is implemented on.

## Details

- `runtime/Process.cs`
  - `LispProcess` — wraps `System.Diagnostics.Process` and exposes its redirected
    stdio as Lisp streams.
  - `ProcessStreamReader` — drains stdout/stderr to *true* EOF on a background
    thread into an in-memory buffer that the Lisp-facing reader consumes. Without
    this, a tight CL read loop (e.g. `READ-LINE`) over a fast-exiting child can
    mistake a transient empty-pipe read for EOF and truncate the output.
- `runtime/Startup.cs` — register the public `DOTCL` API: `launch-process`,
  `process-input` / `process-output` / `process-error`, `process-pid`,
  `process-wait`, `process-alive-p`, `process-exit-code`, `process-kill`.
- `test/regression/process.lisp` — regression tests: live output stream, pid,
  blocking wait, exit code, liveness, and a stdin round-trip that asserts the
  child's output is read back in full (no truncation).

## Notes

This PR lands the runtime primitive only. The UIOP `run-program` integration that
consumes it is bundled through dotcl's asdf and ships separately.
